### PR TITLE
update to align with SGX DCAP 1.7 header file change 

### DIFF
--- a/util/inc/CSGXECDSAQuoteVerifier.h
+++ b/util/inc/CSGXECDSAQuoteVerifier.h
@@ -17,7 +17,7 @@
 
 #include <utility>
 #include "sgx_ql_lib_common.h"
-#include "qve_header.h"
+#include "sgx_qve_header.h"
 #include "sgx_ea.h"
 #include "sgx_eid.h"
 


### PR DESCRIPTION
In SGX DCAP 1.7, it renames qve_header.h to sgx_qve_header.h, update the code accordingly.